### PR TITLE
[codex] reject invalid migration versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![pipeline](https://github.com/acim/mig/actions/workflows/pipeline.yaml/badge.svg)](https://github.com/acim/mig/actions/workflows/pipeline.yaml)
 [![Go Reference](https://pkg.go.dev/badge/go.acim.net/mig.svg)](https://pkg.go.dev/go.acim.net/mig)
 [![Go Report](https://goreportcard.com/badge/go.acim.net/mig)](https://goreportcard.com/report/go.acim.net/mig)
-![Go Coverage](https://img.shields.io/badge/coverage-92.2%25-brightgreen?style=flat&logo=go)
+![Go Coverage](https://img.shields.io/badge/coverage-92.0%25-brightgreen?style=flat&logo=go)
 
 Go PostgreSQL database schema migration library.
 

--- a/docs/superpowers/plans/2026-06-18-review-fix-checklist.md
+++ b/docs/superpowers/plans/2026-06-18-review-fix-checklist.md
@@ -30,19 +30,21 @@
 
 ## Important
 
-- [ ] **Reject migration version zero**
+- [x] **Reject migration version zero**
   - Files: `migrations.go`, `migrations_test.go`
   - Finding: `0.sql` or `000-name.sql` loads as version `0`, but fresh databases also report last version `0`, and `Migrate` only applies migrations with `Version > lastVersion`; the migration is silently skipped forever.
   - References: `migrations.go:61`, `pgx.go:69`, `mig.go:95`
   - Fix direction: Return `ErrInvalidVersion` for parsed version `0`. Add `FromDir` and, if practical, `FromEmbedFS` coverage.
   - Verification: `go test -run 'TestFrom.*Version' -count=1 ./...`
+  - Fixed: loader parsing rejects version `0`, and `Mig.Migrate` validates direct `Migrations` construction before database execution. Verified with `TestFromDirReturnsInvalidVersionErrorForZeroVersion` and real PostgreSQL-backed `TestPgxMigrateRejectsZeroVersionMigration`.
 
-- [ ] **Return an error for overflowing migration version prefixes**
+- [x] **Return an error for overflowing migration version prefixes**
   - Files: `migrations.go`, `migrations_test.go`
   - Finding: `strconv.ParseUint` errors are ignored, so an overflowing prefix can become `math.MaxUint64` and poison future version ordering/state.
   - References: `migrations.go:61`
   - Fix direction: Check the parse error and wrap `ErrInvalidVersion` with the offending filename.
   - Verification: `go test -run 'TestFrom.*Version' -count=1 ./...`
+  - Fixed: loader parsing now checks `strconv.ParseUint` errors and returns `ErrInvalidVersion` for overflowing prefixes. Verified with `TestFromDirReturnsInvalidVersionErrorForOverflowingVersion`.
 
 - [ ] **Make custom table names safe SQL identifiers**
   - Files: `mig.go`, `pgx.go`, `pgx_internal_test.go`, `README.md`

--- a/mig.go
+++ b/mig.go
@@ -65,6 +65,10 @@ func FromPgx(ms Migrations, conn *pgx.Conn, opts ...Option) *Mig {
 }
 
 func (d *Mig) Migrate(ctx context.Context) error {
+	if err := d.ms.Validate(); err != nil {
+		return err
+	}
+
 	return d.db.Migrate(ctx, d.ms)
 }
 

--- a/migrations.go
+++ b/migrations.go
@@ -58,7 +58,10 @@ func migrations(fS fs.FS, files []fs.DirEntry, path string) (Migrations, error) 
 			return nil, fmt.Errorf("%w: %s", ErrInvalidVersion, filepath.Base(fileName))
 		}
 
-		version, _ := strconv.ParseUint(id, 10, 64)
+		version, err := strconv.ParseUint(id, 10, 64)
+		if err != nil || version == 0 {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidVersion, filepath.Base(fileName))
+		}
 
 		if seen[version] {
 			return nil, fmt.Errorf("%w: %d", ErrDuplicateVersion, version)
@@ -106,6 +109,16 @@ type Migration struct {
 	Name    string
 	Path    string
 	SQL     string
+}
+
+func (ms Migrations) Validate() error {
+	for _, m := range ms {
+		if m.Version == 0 {
+			return fmt.Errorf("%w: %s", ErrInvalidVersion, m.Path)
+		}
+	}
+
+	return nil
 }
 
 func numberPrefix(s string) string {

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -99,6 +99,41 @@ func TestFromDirReturnsInvalidVersionError(t *testing.T) {
 	}
 }
 
+func TestFromDirReturnsInvalidVersionErrorForZeroVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"0.sql", "000-initial.sql"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("SELECT 1"), 0o600); err != nil {
+				t.Fatalf("write migration: %v", err)
+			}
+
+			_, err := mig.FromDir(dir)
+			if !errors.Is(err, mig.ErrInvalidVersion) {
+				t.Fatalf("FromDir() error=%v; want invalid version error", err)
+			}
+		})
+	}
+}
+
+func TestFromDirReturnsInvalidVersionErrorForOverflowingVersion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	name := "18446744073709551616-too-large.sql"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("SELECT 1"), 0o600); err != nil {
+		t.Fatalf("write migration: %v", err)
+	}
+
+	_, err := mig.FromDir(dir)
+	if !errors.Is(err, mig.ErrInvalidVersion) {
+		t.Fatalf("FromDir() error=%v; want invalid version error", err)
+	}
+}
+
 func TestFromDirReturnsDuplicateVersionError(t *testing.T) {
 	t.Parallel()
 

--- a/pgx_internal_test.go
+++ b/pgx_internal_test.go
@@ -260,6 +260,44 @@ func TestPgxMigrateWrapsSetLockIDError(t *testing.T) {
 	}
 }
 
+func TestPgxMigrateRejectsZeroVersionMigration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long test")
+	}
+
+	ctx := context.Background()
+	tableName := testTableName(t, "zero_versions")
+	sideEffectTable := testTableName(t, "zero_side_effects")
+	pool := pgxPool(ctx, t)
+	dropTable(ctx, t, pool, tableName)
+	dropTable(ctx, t, pool, sideEffectTable)
+	t.Cleanup(func() {
+		dropTable(ctx, t, pool, tableName)
+		dropTable(ctx, t, pool, sideEffectTable)
+	})
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire connection: %v", err)
+	}
+	defer conn.Release()
+
+	migrator := New(Migrations{{
+		Version: 0,
+		Path:    "000-invalid.sql",
+		SQL:     "CREATE TABLE " + sideEffectTable + " (id integer)",
+	}}, newPgxDB(newPgxPoolConn(conn), tableName))
+
+	err = migrator.Migrate(ctx)
+	if !errors.Is(err, ErrInvalidVersion) {
+		t.Fatalf("Migrate() error=%v; want invalid version error", err)
+	}
+
+	if tableExists(ctx, t, pool, sideEffectTable) {
+		t.Fatalf("side effect table %s exists; want zero-version migration rejected before execution", sideEffectTable)
+	}
+}
+
 func pgxPool(ctx context.Context, t *testing.T) *pgxpool.Pool {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- reject zero-version migration files during loading
- reject overflowing migration version prefixes
- validate direct Migrations construction before database execution
- update review checklist and coverage badge

## Test Plan
- env MIG_TEST_DSN=postgres://postgres@localhost:15432/mig go test -race -coverprofile=coverage.out ./...
- env MIG_TEST_DSN=postgres://postgres@localhost:15432/mig make test

Note: tests were run against PostgreSQL from podman-compose using docker-compose.test.yml.