### PR TITLE
Validate migration order and expose target version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![pipeline](https://github.com/acim/mig/actions/workflows/pipeline.yaml/badge.svg)](https://github.com/acim/mig/actions/workflows/pipeline.yaml)
 [![Go Reference](https://pkg.go.dev/badge/go.acim.net/mig.svg)](https://pkg.go.dev/go.acim.net/mig)
 [![Go Report](https://goreportcard.com/badge/go.acim.net/mig)](https://goreportcard.com/report/go.acim.net/mig)
-![Go Coverage](https://img.shields.io/badge/coverage-96.5%25-brightgreen?style=flat&logo=go)
+![Go Coverage](https://img.shields.io/badge/coverage-96.8%25-brightgreen?style=flat&logo=go)
 
 Go PostgreSQL database schema migration library.
 
@@ -14,6 +14,10 @@ Go PostgreSQL database schema migration library.
 In theory, you can also make an implementation for any database using _mig.Database_ interface and instantiate **mig** using _mig.New_ constructor. Since there are other migration libraries supporting multiple databases using Go's standard library's interface _database/sql_, this project has no intention to make such implementations since there is no other library specific to _pgx_ driver. As of now, there is only [tern](https://github.com/jackc/tern) CLI, but it doesn't provide a library.
 
 Custom migration table names must be simple PostgreSQL identifiers such as `schema_migrations` or schema-qualified identifiers such as `app.schema_migrations`. Each identifier part must start with a letter or underscore and contain only letters, digits, and underscores.
+
+`Migrations.Validate` rejects invalid, duplicate, and out-of-order versions. Use
+`Migrations.TargetVersion` when a caller needs the newest version from a
+validated, non-empty migration set.
 
 ## Warning :construction:
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,13 @@ This project is in an early stage so you can expect API breaking changes until t
 ## Breaking changes in v0.4.0
 
 - `Migrations.Validate` now rejects duplicate and out-of-order versions.
-  Previously tolerated unsorted manually constructed migration sets now fail
-  before database migration begins.
+  Previously tolerated manually constructed migration sets with duplicate or
+  unsorted versions now fail before database migration begins. Remove duplicate
+  versions and sort the remaining set with `sort.Sort(&ms)` before passing it to
+  `mig`.
+- `ErrInvalidVersion` message text changed from
+  `invalid migration version prefix` to `invalid migration version`; match it
+  with `errors.Is`, not string comparison.
 
 ## Breaking changes in v0.3.0
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![pipeline](https://github.com/acim/mig/actions/workflows/pipeline.yaml/badge.svg)](https://github.com/acim/mig/actions/workflows/pipeline.yaml)
 [![Go Reference](https://pkg.go.dev/badge/go.acim.net/mig.svg)](https://pkg.go.dev/go.acim.net/mig)
 [![Go Report](https://goreportcard.com/badge/go.acim.net/mig)](https://goreportcard.com/report/go.acim.net/mig)
-![Go Coverage](https://img.shields.io/badge/coverage-96.9%25-brightgreen?style=flat&logo=go)
+![Go Coverage](https://img.shields.io/badge/coverage-97.0%25-brightgreen?style=flat&logo=go)
 
 Go PostgreSQL database schema migration library.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![pipeline](https://github.com/acim/mig/actions/workflows/pipeline.yaml/badge.svg)](https://github.com/acim/mig/actions/workflows/pipeline.yaml)
 [![Go Reference](https://pkg.go.dev/badge/go.acim.net/mig.svg)](https://pkg.go.dev/go.acim.net/mig)
 [![Go Report](https://goreportcard.com/badge/go.acim.net/mig)](https://goreportcard.com/report/go.acim.net/mig)
-![Go Coverage](https://img.shields.io/badge/coverage-96.8%25-brightgreen?style=flat&logo=go)
+![Go Coverage](https://img.shields.io/badge/coverage-96.9%25-brightgreen?style=flat&logo=go)
 
 Go PostgreSQL database schema migration library.
 
@@ -22,6 +22,12 @@ validated, non-empty migration set.
 ## Warning :construction:
 
 This project is in an early stage so you can expect API breaking changes until the first major release.
+
+## Breaking changes in v0.4.0
+
+- `Migrations.Validate` now rejects duplicate and out-of-order versions.
+  Previously tolerated unsorted manually constructed migration sets now fail
+  before database migration begins.
 
 ## Breaking changes in v0.3.0
 

--- a/mig_test.go
+++ b/mig_test.go
@@ -167,6 +167,25 @@ func TestMigrateRejectsOutOfOrderVersionsBeforeUsingDatabase(t *testing.T) {
 	}
 }
 
+func TestMigrateRejectsDuplicateVersionsBeforeUsingDatabase(t *testing.T) {
+	t.Parallel()
+
+	db := &dbFake{} //nolint:exhaustruct
+	m := mig.New(mig.Migrations{
+		{Version: 1, Path: "001-first.sql", SQL: "SELECT 1"},
+		{Version: 2, Path: "002-second.sql", SQL: "SELECT 2"},
+		{Version: 1, Path: "001-duplicate.sql", SQL: "SELECT 1"},
+	}, db)
+
+	err := m.Migrate(context.Background())
+	if !errors.Is(err, mig.ErrDuplicateVersion) {
+		t.Fatalf("Migrate() error=%v; want duplicate version error", err)
+	}
+	if db.migrateCalled {
+		t.Fatal("database Migrate called for duplicate migrations")
+	}
+}
+
 func TestFromPgxReturnsMigrator(t *testing.T) {
 	t.Parallel()
 

--- a/mig_test.go
+++ b/mig_test.go
@@ -149,6 +149,24 @@ func TestMigrateReturnsInvalidVersionErrorForPostgresBigintOverflow(t *testing.T
 	}
 }
 
+func TestMigrateRejectsOutOfOrderVersionsBeforeUsingDatabase(t *testing.T) {
+	t.Parallel()
+
+	db := &dbFake{} //nolint:exhaustruct
+	m := mig.New(mig.Migrations{
+		{Version: 2, Path: "002-second.sql", SQL: "SELECT 2"},
+		{Version: 1, Path: "001-first.sql", SQL: "SELECT 1"},
+	}, db)
+
+	err := m.Migrate(context.Background())
+	if !errors.Is(err, mig.ErrOutOfOrderVersion) {
+		t.Fatalf("Migrate() error=%v; want out-of-order version error", err)
+	}
+	if db.migrateCalled {
+		t.Fatal("database Migrate called for out-of-order migrations")
+	}
+}
+
 func TestFromPgxReturnsMigrator(t *testing.T) {
 	t.Parallel()
 

--- a/migrations.go
+++ b/migrations.go
@@ -14,8 +14,10 @@ import (
 )
 
 var (
-	ErrInvalidVersion   = errors.New("invalid migration version prefix")
-	ErrDuplicateVersion = errors.New("duplicate version")
+	ErrInvalidVersion    = errors.New("invalid migration version prefix")
+	ErrDuplicateVersion  = errors.New("duplicate version")
+	ErrOutOfOrderVersion = errors.New("migration version out of order")
+	ErrNoMigrations      = errors.New("no migrations")
 )
 
 const maxPostgresBigintVersion = uint64(1<<63 - 1)
@@ -113,14 +115,45 @@ type Migration struct {
 	SQL     string
 }
 
+// Validate checks that migration versions are valid and strictly increasing.
 func (ms Migrations) Validate() error {
-	for _, m := range ms {
+	for i, m := range ms {
 		if m.Version == 0 || m.Version > maxPostgresBigintVersion {
 			return fmt.Errorf("%w: %s", ErrInvalidVersion, m.Path)
+		}
+		if i == 0 {
+			continue
+		}
+
+		previous := ms[i-1]
+		if m.Version == previous.Version {
+			return fmt.Errorf("%w: %d", ErrDuplicateVersion, m.Version)
+		}
+		if m.Version < previous.Version {
+			return fmt.Errorf(
+				"%w: migration %d from %s follows migration %d from %s",
+				ErrOutOfOrderVersion,
+				m.Version,
+				m.Path,
+				previous.Version,
+				previous.Path,
+			)
 		}
 	}
 
 	return nil
+}
+
+// TargetVersion returns the newest version in a valid, non-empty migration set.
+func (ms Migrations) TargetVersion() (uint64, error) {
+	if len(ms) == 0 {
+		return 0, ErrNoMigrations
+	}
+	if err := ms.Validate(); err != nil {
+		return 0, err
+	}
+
+	return ms[len(ms)-1].Version, nil
 }
 
 func numberPrefix(s string) string {

--- a/migrations.go
+++ b/migrations.go
@@ -45,7 +45,7 @@ func FromEmbedFS(fs embed.FS, path string) (Migrations, error) {
 }
 
 func migrations(fS fs.FS, files []fs.DirEntry, path string) (Migrations, error) {
-	seen := make(map[uint64]bool, len(files))
+	seen := make(map[uint64]string, len(files))
 	ms := make(Migrations, 0, len(files))
 
 	for _, file := range files {
@@ -67,12 +67,25 @@ func migrations(fS fs.FS, files []fs.DirEntry, path string) (Migrations, error) 
 		}
 
 		version, err := strconv.ParseUint(id, 10, 64)
-		if err != nil || version == 0 || version > maxPostgresBigintVersion {
-			return nil, fmt.Errorf("%w: %s", ErrInvalidVersion, filepath.Base(fileName))
+		if err != nil {
+			return nil, fmt.Errorf("%w: unparseable version in %s", ErrInvalidVersion, fileName)
+		}
+		if version == 0 || version > maxPostgresBigintVersion {
+			return nil, fmt.Errorf(
+				"%w: version must be between 1 and %d in %s",
+				ErrInvalidVersion,
+				maxPostgresBigintVersion,
+				fileName,
+			)
 		}
 
-		if seen[version] {
-			return nil, fmt.Errorf("%w: %d", ErrDuplicateVersion, version)
+		if first, ok := seen[version]; ok {
+			return nil, fmt.Errorf(
+				"%w: %s duplicates %s",
+				ErrDuplicateVersion,
+				fileName,
+				first,
+			)
 		}
 
 		name := strings.TrimPrefix(fileName, id)
@@ -92,7 +105,7 @@ func migrations(fS fs.FS, files []fs.DirEntry, path string) (Migrations, error) 
 			SQL:     string(sql),
 		})
 
-		seen[version] = true
+		seen[version] = fileName
 	}
 
 	sort.Sort(&ms)

--- a/migrations.go
+++ b/migrations.go
@@ -59,7 +59,11 @@ func migrations(fS fs.FS, files []fs.DirEntry, path string) (Migrations, error) 
 		id := numberPrefix(filepath.Base(fileName))
 
 		if len(id) == 0 {
-			return nil, fmt.Errorf("%w: %s", ErrInvalidVersion, filepath.Base(fileName))
+			return nil, fmt.Errorf(
+				"%w: missing numeric prefix in %s",
+				ErrInvalidVersion,
+				filepath.Base(fileName),
+			)
 		}
 
 		version, err := strconv.ParseUint(id, 10, 64)
@@ -120,15 +124,20 @@ type Migration struct {
 // It returns ErrInvalidVersion, ErrDuplicateVersion, or ErrOutOfOrderVersion
 // when the corresponding invariant is violated.
 func (ms Migrations) Validate() error {
-	seen := make(map[uint64]struct{}, len(ms))
+	seen := make(map[uint64]int, len(ms))
 	for i, m := range ms {
 		if m.Version == 0 || m.Version > maxPostgresBigintVersion {
 			return fmt.Errorf("%w: %s", ErrInvalidVersion, describeMigration(i, m))
 		}
-		if _, ok := seen[m.Version]; ok {
-			return fmt.Errorf("%w: %d", ErrDuplicateVersion, m.Version)
+		if first, ok := seen[m.Version]; ok {
+			return fmt.Errorf(
+				"%w: %s duplicates %s",
+				ErrDuplicateVersion,
+				describeMigration(i, m),
+				describeMigration(first, ms[first]),
+			)
 		}
-		seen[m.Version] = struct{}{}
+		seen[m.Version] = i
 		if i == 0 {
 			continue
 		}

--- a/migrations.go
+++ b/migrations.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	ErrInvalidVersion    = errors.New("invalid migration version prefix")
+	ErrInvalidVersion    = errors.New("invalid migration version")
 	ErrDuplicateVersion  = errors.New("duplicate version")
 	ErrOutOfOrderVersion = errors.New("migration version out of order")
 	ErrNoMigrations      = errors.New("no migrations")
@@ -115,28 +115,31 @@ type Migration struct {
 	SQL     string
 }
 
-// Validate checks that migration versions are valid and strictly increasing.
+// Validate checks that migration versions are valid, unique, and strictly
+// increasing. An empty migration set is valid because migrating it is a no-op.
+// It returns ErrInvalidVersion, ErrDuplicateVersion, or ErrOutOfOrderVersion
+// when the corresponding invariant is violated.
 func (ms Migrations) Validate() error {
+	seen := make(map[uint64]struct{}, len(ms))
 	for i, m := range ms {
 		if m.Version == 0 || m.Version > maxPostgresBigintVersion {
-			return fmt.Errorf("%w: %s", ErrInvalidVersion, m.Path)
+			return fmt.Errorf("%w: %s", ErrInvalidVersion, describeMigration(i, m))
 		}
+		if _, ok := seen[m.Version]; ok {
+			return fmt.Errorf("%w: %d", ErrDuplicateVersion, m.Version)
+		}
+		seen[m.Version] = struct{}{}
 		if i == 0 {
 			continue
 		}
 
 		previous := ms[i-1]
-		if m.Version == previous.Version {
-			return fmt.Errorf("%w: %d", ErrDuplicateVersion, m.Version)
-		}
 		if m.Version < previous.Version {
 			return fmt.Errorf(
-				"%w: migration %d from %s follows migration %d from %s",
+				"%w: %s follows %s",
 				ErrOutOfOrderVersion,
-				m.Version,
-				m.Path,
-				previous.Version,
-				previous.Path,
+				describeMigration(i, m),
+				describeMigration(i-1, previous),
 			)
 		}
 	}
@@ -144,7 +147,18 @@ func (ms Migrations) Validate() error {
 	return nil
 }
 
-// TargetVersion returns the newest version in a valid, non-empty migration set.
+func describeMigration(index int, migration Migration) string {
+	description := fmt.Sprintf("migration at index %d", index)
+	if migration.Path != "" {
+		description += " from " + migration.Path
+	}
+
+	return fmt.Sprintf("%s with version %d", description, migration.Version)
+}
+
+// TargetVersion validates the migration set and returns its newest version. It
+// returns ErrNoMigrations if the set is empty, or an error from Validate if the
+// set is invalid.
 func (ms Migrations) TargetVersion() (uint64, error) {
 	if len(ms) == 0 {
 		return 0, ErrNoMigrations

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -107,6 +107,11 @@ func TestFromDirReturnsInvalidVersionErrorForZeroVersion(t *testing.T) {
 			if !errors.Is(err, mig.ErrInvalidVersion) {
 				t.Fatalf("FromDir() error=%v; want invalid version error", err)
 			}
+			want := mig.ErrInvalidVersion.Error() +
+				": version must be between 1 and 9223372036854775807 in " + name
+			if err.Error() != want {
+				t.Fatalf("FromDir() error=%q; want %q", err, want)
+			}
 		})
 	}
 }
@@ -124,6 +129,10 @@ func TestFromDirReturnsInvalidVersionErrorForOverflowingVersion(t *testing.T) {
 	if !errors.Is(err, mig.ErrInvalidVersion) {
 		t.Fatalf("FromDir() error=%v; want invalid version error", err)
 	}
+	want := mig.ErrInvalidVersion.Error() + ": unparseable version in " + name
+	if err.Error() != want {
+		t.Fatalf("FromDir() error=%q; want %q", err, want)
+	}
 }
 
 func TestFromDirReturnsInvalidVersionErrorForPostgresBigintOverflow(t *testing.T) {
@@ -138,6 +147,11 @@ func TestFromDirReturnsInvalidVersionErrorForPostgresBigintOverflow(t *testing.T
 	_, err := mig.FromDir(dir)
 	if !errors.Is(err, mig.ErrInvalidVersion) {
 		t.Fatalf("FromDir() error=%v; want invalid version error", err)
+	}
+	want := mig.ErrInvalidVersion.Error() +
+		": version must be between 1 and 9223372036854775807 in " + name
+	if err.Error() != want {
+		t.Fatalf("FromDir() error=%q; want %q", err, want)
 	}
 }
 
@@ -179,6 +193,10 @@ func TestFromDirReturnsDuplicateVersionError(t *testing.T) {
 	if !errors.Is(err, mig.ErrDuplicateVersion) {
 		t.Fatalf("FromDir() error=%v; want duplicate version error", err)
 	}
+	want := mig.ErrDuplicateVersion.Error() + ": 1-two.sql duplicates 001-one.sql"
+	if err.Error() != want {
+		t.Fatalf("FromDir() error=%q; want %q", err, want)
+	}
 }
 
 func TestMigrationsValidateRejectsDuplicateVersion(t *testing.T) {
@@ -208,7 +226,8 @@ func TestMigrationsValidateRejectsNonAdjacentDuplicateVersion(t *testing.T) {
 	if !errors.Is(err, mig.ErrDuplicateVersion) {
 		t.Fatalf("Validate() error=%v; want duplicate version error", err)
 	}
-	want := "duplicate version: migration at index 2 from 001-duplicate.sql with version 1 duplicates " +
+	want := mig.ErrDuplicateVersion.Error() +
+		": migration at index 2 from 001-duplicate.sql with version 1 duplicates " +
 		"migration at index 0 from 001-first.sql with version 1"
 	if err.Error() != want {
 		t.Fatalf("Validate() error=%q; want %q", err, want)
@@ -270,7 +289,8 @@ func TestMigrationsValidateDescribesPathlessOutOfOrderVersions(t *testing.T) {
 	if !errors.Is(err, mig.ErrOutOfOrderVersion) {
 		t.Fatalf("Validate() error=%v; want out-of-order version error", err)
 	}
-	want := "migration version out of order: migration at index 1 with version 1 follows " +
+	want := mig.ErrOutOfOrderVersion.Error() +
+		": migration at index 1 with version 1 follows " +
 		"migration at index 0 with version 2"
 	if err.Error() != want {
 		t.Fatalf("Validate() error=%q; want %q", err, want)

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"go.acim.net/mig"
@@ -191,6 +192,21 @@ func TestMigrationsValidateRejectsDuplicateVersion(t *testing.T) {
 	}
 }
 
+func TestMigrationsValidateRejectsNonAdjacentDuplicateVersion(t *testing.T) {
+	t.Parallel()
+
+	migrations := mig.Migrations{
+		{Version: 1, Path: "001-first.sql"},
+		{Version: 2, Path: "002-second.sql"},
+		{Version: 1, Path: "001-duplicate.sql"},
+	}
+
+	err := migrations.Validate()
+	if !errors.Is(err, mig.ErrDuplicateVersion) {
+		t.Fatalf("Validate() error=%v; want duplicate version error", err)
+	}
+}
+
 func TestMigrationsValidateRejectsOutOfOrderVersion(t *testing.T) {
 	t.Parallel()
 
@@ -205,6 +221,54 @@ func TestMigrationsValidateRejectsOutOfOrderVersion(t *testing.T) {
 	}
 }
 
+func TestMigrationsValidateAcceptsEmptySet(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name       string
+		migrations mig.Migrations
+	}{
+		{name: "nil", migrations: nil},
+		{name: "empty", migrations: mig.Migrations{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := test.migrations.Validate(); err != nil {
+				t.Fatalf("Validate() error=%v; want nil", err)
+			}
+		})
+	}
+}
+
+func TestMigrationsValidateDescribesPathlessInvalidVersion(t *testing.T) {
+	t.Parallel()
+
+	err := (mig.Migrations{{Version: 0}}).Validate()
+	if !errors.Is(err, mig.ErrInvalidVersion) {
+		t.Fatalf("Validate() error=%v; want invalid version error", err)
+	}
+	for _, want := range []string{"migration at index 0", "version 0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Validate() error=%q; want it to contain %q", err, want)
+		}
+	}
+}
+
+func TestMigrationsValidateDescribesPathlessOutOfOrderVersions(t *testing.T) {
+	t.Parallel()
+
+	err := (mig.Migrations{{Version: 2}, {Version: 1}}).Validate()
+	if !errors.Is(err, mig.ErrOutOfOrderVersion) {
+		t.Fatalf("Validate() error=%v; want out-of-order version error", err)
+	}
+	for _, want := range []string{"migration at index 1", "migration at index 0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Validate() error=%q; want it to contain %q", err, want)
+		}
+	}
+}
+
 func TestMigrationsTargetVersion(t *testing.T) {
 	t.Parallel()
 
@@ -214,6 +278,18 @@ func TestMigrationsTargetVersion(t *testing.T) {
 	}
 
 	version, err := migrations.TargetVersion()
+	if err != nil {
+		t.Fatalf("TargetVersion() error=%v", err)
+	}
+	if version != 7 {
+		t.Fatalf("TargetVersion()=%d; want 7", version)
+	}
+}
+
+func TestMigrationsTargetVersionAcceptsSingleMigration(t *testing.T) {
+	t.Parallel()
+
+	version, err := (mig.Migrations{{Version: 7, Path: "007-only.sql"}}).TargetVersion()
 	if err != nil {
 		t.Fatalf("TargetVersion() error=%v", err)
 	}

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -86,6 +86,9 @@ func TestFromDirReturnsInvalidVersionError(t *testing.T) {
 	if !errors.Is(err, mig.ErrInvalidVersion) {
 		t.Fatalf("FromDir() error=%v; want invalid version error", err)
 	}
+	if want := "missing numeric prefix in broken.sql"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("FromDir() error=%q; want it to contain %q", err, want)
+	}
 }
 
 func TestFromDirReturnsInvalidVersionErrorForZeroVersion(t *testing.T) {
@@ -205,6 +208,11 @@ func TestMigrationsValidateRejectsNonAdjacentDuplicateVersion(t *testing.T) {
 	if !errors.Is(err, mig.ErrDuplicateVersion) {
 		t.Fatalf("Validate() error=%v; want duplicate version error", err)
 	}
+	want := "duplicate version: migration at index 2 from 001-duplicate.sql with version 1 duplicates " +
+		"migration at index 0 from 001-first.sql with version 1"
+	if err.Error() != want {
+		t.Fatalf("Validate() error=%q; want %q", err, want)
+	}
 }
 
 func TestMigrationsValidateRejectsOutOfOrderVersion(t *testing.T) {
@@ -262,10 +270,10 @@ func TestMigrationsValidateDescribesPathlessOutOfOrderVersions(t *testing.T) {
 	if !errors.Is(err, mig.ErrOutOfOrderVersion) {
 		t.Fatalf("Validate() error=%v; want out-of-order version error", err)
 	}
-	for _, want := range []string{"migration at index 1", "migration at index 0"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("Validate() error=%q; want it to contain %q", err, want)
-		}
+	want := "migration version out of order: migration at index 1 with version 1 follows " +
+		"migration at index 0 with version 2"
+	if err.Error() != want {
+		t.Fatalf("Validate() error=%q; want %q", err, want)
 	}
 }
 

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -177,6 +177,80 @@ func TestFromDirReturnsDuplicateVersionError(t *testing.T) {
 	}
 }
 
+func TestMigrationsValidateRejectsDuplicateVersion(t *testing.T) {
+	t.Parallel()
+
+	migrations := mig.Migrations{
+		{Version: 1, Path: "001-one.sql"},
+		{Version: 1, Path: "001-duplicate.sql"},
+	}
+
+	err := migrations.Validate()
+	if !errors.Is(err, mig.ErrDuplicateVersion) {
+		t.Fatalf("Validate() error=%v; want duplicate version error", err)
+	}
+}
+
+func TestMigrationsValidateRejectsOutOfOrderVersion(t *testing.T) {
+	t.Parallel()
+
+	migrations := mig.Migrations{
+		{Version: 2, Path: "002-second.sql"},
+		{Version: 1, Path: "001-first.sql"},
+	}
+
+	err := migrations.Validate()
+	if !errors.Is(err, mig.ErrOutOfOrderVersion) {
+		t.Fatalf("Validate() error=%v; want out-of-order version error", err)
+	}
+}
+
+func TestMigrationsTargetVersion(t *testing.T) {
+	t.Parallel()
+
+	migrations := mig.Migrations{
+		{Version: 2, Path: "002-second.sql"},
+		{Version: 7, Path: "007-seventh.sql"},
+	}
+
+	version, err := migrations.TargetVersion()
+	if err != nil {
+		t.Fatalf("TargetVersion() error=%v", err)
+	}
+	if version != 7 {
+		t.Fatalf("TargetVersion()=%d; want 7", version)
+	}
+}
+
+func TestMigrationsTargetVersionRejectsEmptySet(t *testing.T) {
+	t.Parallel()
+
+	version, err := (mig.Migrations{}).TargetVersion()
+	if !errors.Is(err, mig.ErrNoMigrations) {
+		t.Fatalf("TargetVersion() error=%v; want no migrations error", err)
+	}
+	if version != 0 {
+		t.Fatalf("TargetVersion()=%d; want 0", version)
+	}
+}
+
+func TestMigrationsTargetVersionRejectsInvalidSet(t *testing.T) {
+	t.Parallel()
+
+	migrations := mig.Migrations{
+		{Version: 2, Path: "002-second.sql"},
+		{Version: 1, Path: "001-first.sql"},
+	}
+
+	version, err := migrations.TargetVersion()
+	if !errors.Is(err, mig.ErrOutOfOrderVersion) {
+		t.Fatalf("TargetVersion() error=%v; want out-of-order version error", err)
+	}
+	if version != 0 {
+		t.Fatalf("TargetVersion()=%d; want 0", version)
+	}
+}
+
 func want() mig.Migrations {
 	return mig.Migrations{
 		{


### PR DESCRIPTION
## What changed

- make `Migrations.Validate` reject duplicate and out-of-order manually constructed migration sets
- add `Migrations.TargetVersion` for retrieving the newest version from a validated, non-empty set
- document the contract and update the measured coverage badge

## Why

Migration execution relies on versions being strictly increasing, but the public `Migrations` type previously allowed callers to construct unsafe unordered sets. Consumers such as Emaia also had to derive the required schema version by indexing the slice directly. This moves both invariants into `acim/mig`.

## Impact

Invalid manually constructed migration sets now fail before database migration begins. Callers can use `TargetVersion` and handle `ErrNoMigrations` explicitly.

## Validation

- `make test` — race-enabled suite passed with 96.8% coverage
- `make lint` — 0 issues
- regression tests were developed red-green for duplicate versions, out-of-order versions, empty target sets, and invalid target sets